### PR TITLE
Kubernetes support for deploying the Voting App

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,25 @@ Run in this directory to build and run the app:
 docker compose up
 ```
 
-The `vote` app will be running at [http://localhost:8080](http://localhost:8080), and the `results` will be at [http://localhost:8081](http://localhost:8081).
+The `vote` app will be running at [http://localhost:8080](http://localhost:8080), and the `results` will be at [http://localhost:8081/results/{session_id}](http://localhost:8081/results/1). {session_id} is the ID of the voting session you want to see results for.
+
+## Run the app in Kubernetes
+
+The folder k8s-specifications contains the YAML specifications of the Voting App's services.
+
+Run the following command to create the deployments and services. Note it will create these resources in your current namespace (`default` if you haven't changed it.)
+
+```shell
+kubectl create -f k8s-specifications/
+```
+
+The `vote` web app is then available on port 31000 on each host of the cluster, the `result` web app is available on port 31001.
+
+To remove them, run:
+
+```shell
+kubectl delete -f k8s-specifications/
+```
 
 ## Architecture
 

--- a/k8s-specifications/kafka-deployment.yaml
+++ b/k8s-specifications/kafka-deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kafka
+  template:
+    metadata:
+      labels:
+        app: kafka
+    spec:
+      containers:
+      - name: kafka
+        image: apache/kafka:4.0.0
+        ports:
+        - containerPort: 9092
+        env:
+          - name: KAFKA_LISTENERS
+            value: PLAINTEXT://0.0.0.0:9092,,CONTROLLER://0.0.0.0:9093
+          - name: KAFKA_ADVERTISED_LISTENERS
+            value: PLAINTEXT://kafka:9092
+          - name: KAFKA_BROKER_ID
+            value: "1"
+          - name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
+            value: "1"
+          - name: KAFKA_LOG_FLUSH_INTERVAL_MESSAGES
+            value: "1"
+          - name: KAFKA_NUM_PARTITIONS
+            value: "1"
+          - name: KAFKA_NODE_ID
+            value: "1"
+          - name: KAFKA_PROCESS_ROLES
+            value: broker,controller
+          - name: KAFKA_CONTROLLER_LISTENER_NAMES
+            value: CONTROLLER
+          - name: KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
+            value: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+          - name: KAFKA_CONTROLLER_QUORUM_VOTERS
+            value: 1@localhost:9093
+          - name: KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
+            value: "1"
+          - name: KAFKA_TRANSACTION_STATE_LOG_MIN_ISR
+            value: "1"
+          - name: KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS
+            value: "0"

--- a/k8s-specifications/kafka-service.yaml
+++ b/k8s-specifications/kafka-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kafka
+  name: kafka
+spec:
+  type: ClusterIP
+  ports:
+  - name: "kafka-service"
+    port: 9092
+    targetPort: 9092
+  selector:
+    app: kafka
+  

--- a/k8s-specifications/result-deployment.yaml
+++ b/k8s-specifications/result-deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: result
+  name: result
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: result
+  template:
+    metadata:
+      labels:
+        app: result
+    spec:
+      containers:
+      - name: result
+        image: dedaced/voting_app-result:latest
+        env:
+          - name: VOTE_DB_URL
+            value: jdbc:postgresql://vote-db:5432/cs544
+        ports:
+        - containerPort: 80
+          name: result

--- a/k8s-specifications/result-deployment.yaml
+++ b/k8s-specifications/result-deployment.yaml
@@ -19,7 +19,7 @@ spec:
         image: dedaced/voting_app-result:latest
         env:
           - name: VOTE_DB_URL
-            value: jdbc:postgresql://vote-db:5432/cs544
+            value: postgres://postgres:postgres@vote-db/cs544
         ports:
         - containerPort: 80
           name: result

--- a/k8s-specifications/result-service.yaml
+++ b/k8s-specifications/result-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: result
+  name: result
+spec:
+  type: NodePort
+  ports:
+  - name: "result-service"
+    port: 8081
+    targetPort: 80
+    NodePort: 31001
+  selector:
+    app: result

--- a/k8s-specifications/result-service.yaml
+++ b/k8s-specifications/result-service.yaml
@@ -10,6 +10,6 @@ spec:
   - name: "result-service"
     port: 8081
     targetPort: 80
-    NodePort: 31001
+    nodePort: 31001
   selector:
     app: result

--- a/k8s-specifications/vote-db-deployment.yaml
+++ b/k8s-specifications/vote-db-deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: vote-db
+  name: vote-db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vote-db
+  template:
+    metadata:
+      labels:
+        app: vote-db
+    spec:
+      containers:
+      - image: postgres:17-alpine
+        name: postgres
+        env:
+        - name: POSTGRES_USER
+          value: postgres
+        - name: POSTGRES_PASSWORD
+          value: postgres
+        - name: POSTGRES_DB
+          value: cs544
+        readinessProbe:
+          exec:
+            command: ["pg_isready", "-U", "postgres"]
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 5
+        ports:
+        - containerPort: 5432
+          name: postgres
+        volumeMounts:
+        - mountPath: /var/lib/postgresql/data
+          name: vote-db-data
+      volumes:
+      - name: vote-db-data
+        emptyDir: {} 

--- a/k8s-specifications/vote-db-service.yaml
+++ b/k8s-specifications/vote-db-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: vote-db
+  name: vote-db
+spec:
+  type: ClusterIP
+  ports:
+  - name: "vote-db-service"
+    port: 5432
+    targetPort: 5432
+  selector:
+    app: vote-db
+  

--- a/k8s-specifications/vote-deployment.yaml
+++ b/k8s-specifications/vote-deployment.yaml
@@ -21,7 +21,7 @@ spec:
           - name: KAFKA_BOOTSTRAP_SERVERS
             value: kafka:9092
           - name: SESSION_API_URL
-            value: http://vote-session:8080/sessions
+            value: http://vote-session:8082/sessions
         ports:
         - containerPort: 8080
           name: vote

--- a/k8s-specifications/vote-deployment.yaml
+++ b/k8s-specifications/vote-deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: vote
+  name: vote
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vote
+  template:
+    metadata:
+      labels:
+        app: vote
+    spec:
+      containers:
+      - name: vote
+        image: dedaced/voting_app-vote:latest
+        env:
+          - name: KAFKA_BOOTSTRAP_SERVERS
+            value: kafka:9092
+          - name: SESSION_API_URL
+            value: http://vote-session:8080/sessions
+        ports:
+        - containerPort: 8080
+          name: vote

--- a/k8s-specifications/vote-service.yaml
+++ b/k8s-specifications/vote-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: vote
+  name: vote
+spec:
+  type: NodePort
+  ports:
+  - name: "vote-service"
+    port: 8080
+    targetPort: 8080
+    nodePort: 31000
+  selector:
+    app: vote

--- a/k8s-specifications/vote-session-deployment.yaml
+++ b/k8s-specifications/vote-session-deployment.yaml
@@ -2,17 +2,17 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: vote
-  name: vote
+    app: vote-session
+  name: vote-session
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: vote
+      app: vote-session
   template:
     metadata:
       labels:
-        app: vote
+        app: vote-session
     spec:
       containers:
       - name: vote-session

--- a/k8s-specifications/vote-session-deployment.yaml
+++ b/k8s-specifications/vote-session-deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: vote
+  name: vote
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vote
+  template:
+    metadata:
+      labels:
+        app: vote
+    spec:
+      containers:
+      - name: vote-session
+        image: dedaced/voting_app-vote-session:latest
+        env:
+        - name: VOTE_DB_URL
+          value: "jdbc:postgresql://vote-db:5432/cs544"
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /actuator/health
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 15
+          timeoutSeconds: 5
+          failureThreshold: 3

--- a/k8s-specifications/vote-session-service.yaml
+++ b/k8s-specifications/vote-session-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: vote-session
+  name: vote-session
+spec:
+  selector:
+    app: vote-session
+  ports:
+    - protocol: TCP
+      port: 8082
+      targetPort: 8080
+  type: ClusterIP

--- a/k8s-specifications/worker-deployment.yaml
+++ b/k8s-specifications/worker-deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: worker
+  template:
+    metadata:
+      labels:
+        app: worker
+    spec:
+      containers:
+      - name: worker
+        image: dedaced/voting_app-result-worker:latest
+        env:
+          - name: KAFKA_BOOTSTRAP_SERVERS
+            value: kafka:9092
+          - name: VOTE_DB_URL
+            value: jdbc:postgresql://vote-db:5432/cs544

--- a/k8s-specifications/worker-deployment.yaml
+++ b/k8s-specifications/worker-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: worker
-        image: dedaced/voting_app-result-worker:latest
+        image: dedaced/voting_app-worker:latest
         env:
           - name: KAFKA_BOOTSTRAP_SERVERS
             value: kafka:9092


### PR DESCRIPTION
This pull request introduces Kubernetes support for deploying the Voting App, including YAML specifications for deployments and services, updates to the `README.md` with Kubernetes instructions, and configurations for individual components such as `vote`, `result`, `worker`, and `vote-session`. Below are the most important changes grouped by theme.

### Documentation Updates:
* Updated `README.md` to include instructions for running the app in Kubernetes, specifying commands for creating and deleting Kubernetes resources, and detailing the ports for accessing the `vote` and `result` web apps.

### Kubernetes Deployment Configurations:
* Added `k8s-specifications/vote-deployment.yaml` for the `vote` app, specifying its container image, environment variables, and port.
* Added `k8s-specifications/result-deployment.yaml` for the `result` app, specifying its container image, database connection, and port.
* Added `k8s-specifications/vote-session-deployment.yaml` for the `vote-session` service, including readiness probes and database connection details.
* Added `k8s-specifications/worker-deployment.yaml` for the `worker` component, specifying Kafka and database connection details.
* Added `k8s-specifications/vote-db-deployment.yaml` for the PostgreSQL database, including environment variables, readiness probes, and volume configuration.

### Kubernetes Service Configurations:
* Added `k8s-specifications/vote-service.yaml` to expose the `vote` app via NodePort on port 31000.
* Added `k8s-specifications/result-service.yaml` to expose the `result` app via NodePort on port 31001.
* Added `k8s-specifications/vote-session-service.yaml` to expose the `vote-session` service as a ClusterIP service.
* Added `k8s-specifications/vote-db-service.yaml` to expose the PostgreSQL database as a ClusterIP service.
* Added `k8s-specifications/kafka-service.yaml` to expose Kafka as a ClusterIP service.

### Kafka Configuration:
* Added `k8s-specifications/kafka-deployment.yaml` for deploying a Kafka broker with environment variables configured for listeners, advertised listeners, and replication settings.